### PR TITLE
Integrate beacon containers with SSZ and Merkleise

### DIFF
--- a/src/dafny/beacon/BeaconChain.dfy
+++ b/src/dafny/beacon/BeaconChain.dfy
@@ -27,22 +27,6 @@ module BeaconChain {
     // import opened Attestations
     import opened Validators
     
-     /**
-     *  Beacon chain block header.
-     *
-     *  @param  slot
-     *  @param  proposer_index
-     *  @param  parent_root
-     *  @param  state_root
-     *  @param  body_root
-     */
-    datatype BeaconBlockHeader = BeaconBlockHeader(
-        slot: Slot,
-        // proposer_index: ValidatorIndex,
-        parent_root: Root,
-        state_root: Root
-        // body_root: Root
-    )
 
     /**
      *  Beacon block body.
@@ -82,7 +66,7 @@ module BeaconChain {
      *  Seems signed beacon block has merged into this one.
      *  Where is the message?
      *
-     *  @note: Note that hash_tree_root(BeaconBlock) == hash_tree_root(BeaconBlockHeader) 
+     *  @note: Note that getHashTreeRootBytes32(BeaconBlock) == getHashTreeRootBytes32(BeaconBlockHeader) 
      *  and thus signatures of each are equivalent.
      *
      *  @param  slot            The slot for which this block is proposed for. Must be greater 

--- a/src/dafny/beacon/BeaconConstants.dfy
+++ b/src/dafny/beacon/BeaconConstants.dfy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may 
+ * not use this file except in compliance with the License. You may obtain 
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software dis-
+ * tributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
+ * License for the specific language governing permissions and limitations 
+ * under the License.
+ */
+ 
+include "../utils/Eth2Types.dfy"
+include "../utils/Helpers.dfy"
+include "../ssz/Constants.dfy"
+include "../merkle/Merkleise.dfy"
+include "../ssz/Eth2TypeDependentConstants.dfy"
+
+module BeaconConstants {
+    import opened Eth2Types
+    import opened Helpers
+    import opened Constants
+    import opened SSZ_Merkleise
+    import opened Eth2TypeDependentConstants
+
+    /** The historical roots type.  */
+    const EMPTY_HIST_ROOTS := Vector(timeSeq<Bytes32>(EMPTY_BYTES32, SLOTS_PER_HISTORICAL_ROOT as int))
+
+    const EMPTY_BLOCK_HEADER: Serialisable := BeaconBlockHeader(Uint64(0), EMPTY_BYTES32, EMPTY_BYTES32)
+    
+    /**
+     *  Genesis (initial) beacon state.
+     *  
+     *  @link{https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md#genesis-state}
+     */
+    const GENESIS_STATE: BeaconState := BeaconState(Uint64(0), EMPTY_BLOCK_HEADER, EMPTY_HIST_ROOTS, EMPTY_HIST_ROOTS)
+
+    /**
+     *  Genesis block (header).
+     *
+     *  @link{https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md#genesis-block}
+     *  @note   In this simplified version blocks are same as headers.
+     */
+    const GENESIS_BLOCK_HEADER: BeaconBlockHeader := BeaconBlockHeader(
+        Uint64(0),  
+        EMPTY_BYTES32 , 
+        getHashTreeRootBytes32(GENESIS_STATE)
+    )
+
+}

--- a/src/dafny/beacon/StateTransition.dfy
+++ b/src/dafny/beacon/StateTransition.dfy
@@ -15,7 +15,10 @@
 include "../utils/Eth2Types.dfy"
 include "../utils/Helpers.dfy"
 include "../ssz/Constants.dfy"
+include "BeaconConstants.dfy"
 include "BeaconChain.dfy"
+include "../ssz/Eth2TypeDependentConstants.dfy"
+include "../merkle/Merkleise.dfy"
 
 /**
  * State transition function for the Beacon Chain.
@@ -27,93 +30,19 @@ module StateTransition {
     import opened Constants
     import opened BeaconChain
     import opened Helpers
+    import opened BeaconConstants
+    import opened Eth2TypeDependentConstants
+    import opened SSZ_Merkleise
 
-    /** The default zeroed Bytes32.  */
-    const SEQ_EMPTY_32_BYTES := timeSeq<byte>(0,32)
-    
-    /**
-     *  The default (empty) Bytes32
-     */
-    const EMPTY_BYTES32 : Bytes32 := Bytes(SEQ_EMPTY_32_BYTES)
 
-    /** The historical roots type.  */
-    const EMPTY_HIST_ROOTS := timeSeq<Bytes32>(EMPTY_BYTES32, SLOTS_PER_HISTORICAL_ROOT as int)
 
-    type VectorOfHistRoots = x : seq<Bytes32> |  |x| == SLOTS_PER_HISTORICAL_ROOT as int
-        witness EMPTY_HIST_ROOTS
 
-    /**
-     *  Compute Root/Hash/Bytes32 for different types.
-     *  
-     *  @todo   Use the hash_tree_root from Merkle.
-     */
-    function method hash_tree_root<T(==)>(t : T) : Bytes32 
-        ensures hash_tree_root(t) != EMPTY_BYTES32
-
-    /** Collision free hash function. 
-     *  This does not seem to affect the proofs so far, so
-     *  this lemma is commented out.
-     **/
-    // lemma {:axiom} foo<T(==)>(t1: T, t2: T) 
-        // ensures t1 == t2 <==> hash_tree_root(t1) == hash_tree_root(t2)
-
-   
-    /** 
-     * @link{https://notes.ethereum.org/@djrtwo/Bkn3zpwxB?type=view} 
-     * The beacon chain’s state (BeaconState) is the core object around 
-     * which the specification is built. The BeaconState encapsulates 
-     * all of the information pertaining to: 
-     *  - who the validators are, 
-     *  - in what state each of them is in, 
-     *  - which chain in the block tree this state belongs to, and 
-     *  - a hash-reference to the Ethereum 1 chain.
-
-     * Beginning with the genesis state, the post state of a block is 
-     * considered valid if it passes all of the guards within the state 
-     * transition function. Thus, the precondition of a block is 
-     * recursively defined as being a valid postcondition of running 
-     * the state transition function on the previous block and its state 
-     * all the way back to the genesis state.
-     *
-     * @param   slot                            Time is divided into “slots” of fixed length 
-     *                                          at which actions occur and state transitions 
-     *                                          happen. This field tracks the slot of the 
-     *                                          containing state, not necessarily the slot 
-     *                                          according to the local wall clock
-     * @param   latest_block_header             The latest block header seen in the chain 
-     *                                          defining this state. This blockheader has
-     *                                          During the slot transition 
-     *                                          of the block, the header is stored without the 
-     *                                          real state root but instead with a stub of Root
-     *                                          () (empty 0x00 bytes). At the start of the next 
-     *                                          slot transition before anything has been 
-     *                                          modified within state, the state root is 
-     *                                          calculated and added to the 
-     *                                          latest_block_header. This is done to eliminate 
-     *                                          the circular dependency of the state root 
-     *                                          being embedded in the block header
-     * @param   block_roots                     Per-slot store of the recent block roots. 
-     *                                          The block root for a slot is added at the start 
-     *                                          of the next slot to avoid the circular 
-     *                                          dependency due to the state root being embedded 
-     *                                          in the block. For slots that are skipped (no 
-     *                                          block in the chain for the given slot), the 
-     *                                          most recent block root in the chain prior to 
-     *                                          the current slot is stored for the skipped 
-     *                                          slot. When validators attest to a given slot, 
-     *                                          they use this store of block roots as an 
-     *                                          information source to cast their vote.
-     * @param   state_roots                     Per-slot store of the recent state roots. 
-     *                                          The state root for a slot is stored at the 
-     *                                          start of the next slot to avoid a circular 
-     *                                          dependency
-     */
-    datatype BeaconState = BeaconState(
-        slot: Slot,
-        latest_block_header: BeaconBlockHeader,
-        block_roots: VectorOfHistRoots,
-        state_roots: VectorOfHistRoots
-    )
+    function method castToBeaconState(s:RawSerialisable): BeaconState
+    requires s.BeaconState?
+    requires wellTypedContainer(s)
+    {
+        s
+    }    
 
     /**
      *  Whether a block is valid in a given state.
@@ -125,17 +54,17 @@ module StateTransition {
      */
     predicate isValid(s : BeaconState, b : BeaconBlockHeader) 
     {
-        s.slot < b.slot 
+        s.slot.n < b.slot.n
         //  Fast forward s to b.slot and check `b` can be attached to the
         //  resulting state's latest_block_header.
         && b.parent_root == 
-            hash_tree_root(
+            getHashTreeRootBytes32(
                 forwardStateToSlot(resolveStateRoot(s), 
-                b.slot
+                b.slot.n as Slot
             ).latest_block_header) 
-        &&  b.state_root == hash_tree_root(
+        &&  b.state_root == getHashTreeRootBytes32(
                 addBlockToState(
-                    forwardStateToSlot(resolveStateRoot(s), b.slot), 
+                    forwardStateToSlot(resolveStateRoot(s), b.slot.n as Slot), 
                     b
                 )
             )
@@ -152,17 +81,17 @@ module StateTransition {
         /** The next state latest_block_header is same as b except for state_root that is 0. */
         ensures s'.latest_block_header == b.(state_root := EMPTY_BYTES32)
         /** s' slot is now adjusted to the slot of b. */
-        ensures s'.slot == b.slot
+        ensures s'.slot.n == b.slot.n
         /** s' parent_root is the hash of the state obtained by resolving/forwarding s to
             the slot of b.  */
         ensures s'.latest_block_header.parent_root  == 
-            hash_tree_root(
-                forwardStateToSlot(resolveStateRoot(s), b.slot)
+            getHashTreeRootBytes32(
+                forwardStateToSlot(resolveStateRoot(s), b.slot.n as Slot)
                 .latest_block_header
             )
     {
         //  finalise slots before b.slot.
-        var s1 := processSlots(s, b.slot);
+        var s1 := processSlots(s, b.slot.n as Slot);
 
         //  Process block and compute the new state.
         s' := processBlock(s1, b);  
@@ -170,7 +99,7 @@ module StateTransition {
         // Verify state root (from eth2.0 specs)
         // A proof that this assert statement is never violated when isValid() is true.
         // if validate_result:
-        assert (b.state_root == hash_tree_root(s'));
+        assert (b.state_root == getHashTreeRootBytes32(s'));
 
     }  
 
@@ -202,19 +131,19 @@ module StateTransition {
      *                  resolveStateRoot(s); 
      *
      */
-    method processSlots(s: BeaconState, slot: Slot) returns (s' : BeaconState)
-        requires s.slot < slot  //  update in 0.12.0 (was <= before)
+    method {:fuel wellTypedContainer,2}  processSlots(s: BeaconState, slot: Slot) returns (s' : BeaconState)    
+        requires s.slot.n < slot as nat  //  update in 0.12.0 (was <= before)
 
         ensures s' == forwardStateToSlot( resolveStateRoot(s), slot)
         ensures s.latest_block_header.parent_root == s'.latest_block_header.parent_root  
         
         //  Termination ranking function
-        decreases slot - s.slot
+        decreases slot as nat - s.slot.n
     {
         //  Start from the current state and update it with processSlot.
         //  First iteration of the loop in process_slots (Eth2)
         s' := processSlot(s);
-        s':= s'.(slot := s'.slot + 1) ;
+        s':= castToBeaconState(s'.(slot := Uint64(s'.slot.n + 1))) ;
         //  The following asserts are not needed for the proof but provided for readability. 
         assert(s' == resolveStateRoot(s));  
         //  s'.block header state_root should now be resolved
@@ -222,20 +151,20 @@ module StateTransition {
 
         //  Now fast forward to slot
         //  Next iterations of process_slot (Eth2)
-        while (s'.slot < slot)  
-            invariant s'.slot <= slot
+        while (s'.slot.n < slot as nat) 
+            invariant s'.slot.n <= slot as nat
             invariant s'.latest_block_header.state_root != EMPTY_BYTES32
-            invariant s' == forwardStateToSlot(resolveStateRoot(s), s'.slot) // Inv1
-            decreases slot - s'.slot 
+            invariant s' == forwardStateToSlot(resolveStateRoot(s), s'.slot.n as Slot) // Inv1
+            decreases slot as nat - s'.slot.n
         {
             s':= processSlot(s');
 
             //  s'.slot is now processed: history updated and block header resolved
             //  The state's slot is processed and we can advance to the next slot.
-            s':= s'.(slot := s'.slot + 1) ;
+            s':= castToBeaconState(s'.(slot := Uint64(s'.slot.n + 1))) ;
         }
-    }
-
+    }    
+    
     /** 
      *  Cache data for a slot.
      *
@@ -254,8 +183,8 @@ module StateTransition {
      *
      *  @todo       Make this a method to have a def closer to Eth2 implementation.  
      */
-    method processSlot(s: BeaconState) returns (s' : BeaconState)
-        requires s.slot as nat + 1 < 0x10000000000000000 as nat
+    method {:fuel wellTypedContainer,3} {:fuel getHashTreeRootBytes32,0,0} processSlot(s: BeaconState) returns (s' : BeaconState)   
+        requires s.slot.n as nat + 1 < 0x10000000000000000 as nat
 
         ensures  s.latest_block_header.state_root == EMPTY_BYTES32 ==>
             s' == resolveStateRoot(s).(slot := s.slot)
@@ -267,19 +196,19 @@ module StateTransition {
 
         //  Cache state root
         //  Record the hash of the previous state in the history.
-        var previous_state_root := hash_tree_root(s); 
+        var previous_state_root := getHashTreeRootBytes32(s); 
 
-        s' := s'.(state_roots := s'.state_roots[(s'.slot % SLOTS_PER_HISTORICAL_ROOT) as int := previous_state_root]);
+        s' := castToBeaconState(s'.(state_roots :=  Vector(s'.state_roots.v[(s'.slot.n % SLOTS_PER_HISTORICAL_ROOT as nat) as int := previous_state_root])));
 
         //  Cache latest block header state root
         if (s'.latest_block_header.state_root == EMPTY_BYTES32) {
-            s' := s'.(latest_block_header := s'.latest_block_header.(state_root := previous_state_root));
+            s' := castToBeaconState(s'.(latest_block_header := s'.latest_block_header.(state_root := previous_state_root)));
         }
 
         //  Cache block root
-        var previous_block_root := hash_tree_root(s'.latest_block_header);
+        var previous_block_root := getHashTreeRootBytes32(s'.latest_block_header);
 
-        s' := s'.(block_roots := s'.block_roots[(s.slot % SLOTS_PER_HISTORICAL_ROOT) as int := previous_block_root]);
+        s' := castToBeaconState(s'.(block_roots := Vector(s'.block_roots.v[(s.slot.n % SLOTS_PER_HISTORICAL_ROOT as nat) as int := previous_block_root])));
     }
 
     /**
@@ -289,7 +218,7 @@ module StateTransition {
      */
     method processBlock(s: BeaconState, b: BeaconBlockHeader) returns (s' : BeaconState) 
         requires b.slot == s.slot
-        requires b.parent_root == hash_tree_root(s.latest_block_header)
+        requires b.parent_root == getHashTreeRootBytes32(s.latest_block_header)
 
         ensures s' == addBlockToState(s, b)
 
@@ -308,19 +237,22 @@ module StateTransition {
      *
      *  @note   Matches eth2.0 specs except proposer slashing verification
      */
-    method processBlockHeader(s: BeaconState, b: BeaconBlockHeader) returns (s' : BeaconState) 
+    method {:fuel wellTypedContainer,3} processBlockHeader(s: BeaconState, b: BeaconBlockHeader) returns (s' : BeaconState) 
         //  Verify that the slots match
         requires b.slot == s.slot  
         // Verify that the parent matches
-        requires b.parent_root == hash_tree_root(s.latest_block_header) 
+        requires b.parent_root == getHashTreeRootBytes32(s.latest_block_header) 
 
         ensures s' == addBlockToState(s, b)
     {
-        s':= s.(
-            latest_block_header := BeaconBlockHeader(
-                b.slot,
-                b.parent_root,
-                EMPTY_BYTES32
+        s' :=
+        castToBeaconState(
+                s.(
+                latest_block_header := BeaconBlockHeader(
+                    b.slot,
+                    b.parent_root,
+                    EMPTY_BYTES32
+                )
             )
         );
     }
@@ -334,17 +266,19 @@ module StateTransition {
      *  @param  b   A block to add to the state `s`.
      *  @returns    The state `s` updated to point to `b` with state_root set to 0.
      */
-    function addBlockToState(s: BeaconState, b: BeaconBlockHeader) :  BeaconState 
+    function {:fuel wellTypedContainer,3} addBlockToState(s: BeaconState, b: BeaconBlockHeader) :  BeaconState 
         //  Verify that the slots match
         requires b.slot == s.slot  
         // Verify that the parent matches
-        requires b.parent_root == hash_tree_root(s.latest_block_header) 
+        requires b.parent_root == getHashTreeRootBytes32(s.latest_block_header) 
     {
-        s.(
-            latest_block_header := BeaconBlockHeader(
-                b.slot,
-                b.parent_root,
-                EMPTY_BYTES32
+        castToBeaconState(
+            s.(
+                latest_block_header := BeaconBlockHeader(
+                    b.slot,
+                    b.parent_root,
+                    EMPTY_BYTES32
+                )
             )
         )
     }
@@ -354,32 +288,37 @@ module StateTransition {
      *
      *  @param  s   A beacon state.
      *  @returns    A new state `s' such that:
-     *              1. a new latest_block_header' state_root set to the hash_tree_root(s) 
-     *              2. the hash_tree_root(s) archived in the s'.state_roots for the slot
-     *              3. the hash_tree_root of the new_block_header is archived 
+     *              1. a new latest_block_header' state_root set to the getHashTreeRootBytes32(s) 
+     *              2. the getHashTreeRootBytes32(s) archived in the s'.state_roots for the slot
+     *              3. the getHashTreeRootBytes32 of the new_block_header is archived 
      *              in s'.block_roots
      */
-    function resolveStateRoot(s: BeaconState): BeaconState 
+    function {:fuel wellTypedContainer,3} {:fuel getHashTreeRootBytes32,0,0} resolveStateRoot(s: BeaconState): BeaconState 
         //  Make sure s.slot does not  overflow
-        requires s.slot as nat + 1 < 0x10000000000000000 as nat
+        // requires wellTyped(s)
+        requires s.slot.n as nat + 1 < 0x10000000000000000 as nat
         //  parent_root of the state block header is preserved
         ensures s.latest_block_header.parent_root == resolveStateRoot(s).latest_block_header.parent_root
     {
         var new_latest_block_header := 
             if (s.latest_block_header.state_root == EMPTY_BYTES32 ) then 
-                s.latest_block_header.(state_root := hash_tree_root(s))
+                s.latest_block_header.(state_root := getHashTreeRootBytes32(s))
             else 
                 s.latest_block_header
             ;
+
+        assert wellTypedContainer(new_latest_block_header);
         
-        BeaconState(
-            // slot unchanged
-            s.slot + 1,
-            new_latest_block_header,
-            //  add new block_header root to block_roots history.
-            s.block_roots[(s.slot % SLOTS_PER_HISTORICAL_ROOT) as int := hash_tree_root(new_latest_block_header)],
-            //  add previous state root to state_roots history
-            s.state_roots[(s.slot % SLOTS_PER_HISTORICAL_ROOT) as int := hash_tree_root(s)]
+        castToBeaconState(
+            BeaconState(
+                // slot unchanged
+                Uint64(s.slot.n + 1),
+                new_latest_block_header,
+                //  add new block_header root to block_roots history.
+                Vector(s.block_roots.v[(s.slot.n % SLOTS_PER_HISTORICAL_ROOT as nat) as int := getHashTreeRootBytes32(new_latest_block_header)]),
+                //  add previous state root to state_roots history
+                Vector(s.state_roots.v[(s.slot.n % SLOTS_PER_HISTORICAL_ROOT as nat) as int := getHashTreeRootBytes32(s)])
+            )
         )
     }
 
@@ -391,16 +330,16 @@ module StateTransition {
      *  @returns        A new state obtained by  archiving roots and incrementing slot.
      *                  slot.
      */
-    function forwardStateToSlot(s: BeaconState, slot: Slot) : BeaconState 
-        requires s.slot <= slot
+    function {:fuel wellTypedContainer,2} forwardStateToSlot(s: BeaconState, slot: Slot) : BeaconState 
+        requires s.slot.n <= slot as nat
 
-        ensures forwardStateToSlot(s, slot).slot == slot
+        ensures forwardStateToSlot(s, slot).slot.n == slot as nat
         ensures forwardStateToSlot(s, slot).latest_block_header ==  s.latest_block_header
 
         //  termination ranking function
-        decreases slot - s.slot
+        decreases slot as nat - s.slot.n
     {
-        if (s.slot == slot) then 
+        if (s.slot.n == slot as nat) then 
             s
         else
             nextSlot(forwardStateToSlot(s, slot - 1))
@@ -416,19 +355,21 @@ module StateTransition {
      *              the previous state_root and block_root, and copy verbatim the 
      *              latest_block_header.
      */
-    function nextSlot(s : BeaconState) : BeaconState 
+    function {:fuel wellTypedContainer,3} nextSlot(s : BeaconState) : BeaconState 
         //  Make sure s.slot does not overflow
-        requires s.slot as nat + 1 < 0x10000000000000000 as nat
+        requires s.slot.n as nat + 1 < 0x10000000000000000 as nat
     {
         //  Add header root to history of block_roots
-        var new_block_roots := s.block_roots[(s.slot % SLOTS_PER_HISTORICAL_ROOT) as int := hash_tree_root(s.latest_block_header)];
+        var new_block_roots := s.block_roots.v[(s.slot.n % SLOTS_PER_HISTORICAL_ROOT as nat) as int := getHashTreeRootBytes32(s.latest_block_header)];
         //  Add state root to history of state roots
-        var new_state_roots := s.state_roots[(s.slot % SLOTS_PER_HISTORICAL_ROOT) as int := hash_tree_root(s)];
+        var new_state_roots := s.state_roots.v[(s.slot.n % SLOTS_PER_HISTORICAL_ROOT as nat) as int := getHashTreeRootBytes32(s)];
         //  Increment slot and copy latest_block_header
-        s.(
-            slot := s.slot + 1,
-            block_roots := new_block_roots,
-            state_roots := new_state_roots
+        castToBeaconState(
+            s.(
+                slot := Uint64(s.slot.n + 1),
+                block_roots := Vector(new_block_roots),
+                state_roots := Vector(new_state_roots)
+            )
         )
     }
 }

--- a/src/dafny/beacon/helpers/Crypto.dfy
+++ b/src/dafny/beacon/helpers/Crypto.dfy
@@ -14,9 +14,13 @@
 
 include "../../utils/Helpers.dfy"
 include "../../utils/Eth2Types.dfy"
+include "../../ssz/Constants.dfy"
+include "../../ssz/Eth2TypeDependentConstants.dfy"
 
 module {:extern "eth2crypto"} Crypto {
     import opened Eth2Types
+    import opened Constants
+    import opened Eth2TypeDependentConstants
 
     /**
      * Calculate the SHA256 of a sequence of bytes
@@ -26,4 +30,5 @@ module {:extern "eth2crypto"} Crypto {
      * @returns SHA256 hash of `data`
      */
     function method {:extern} hash(data:seq<byte>) : hash32
+    ensures hash(data) != SEQ_EMPTY_32_BYTES
 }

--- a/src/dafny/ssz/Constants.dfy
+++ b/src/dafny/ssz/Constants.dfy
@@ -11,10 +11,11 @@ module Constants {
 
   //  Powers of 2
   const TWO_UP_0 := 1;
-  const TWO_UP_2 := 2 * TWO_UP_0;
+  const TWO_UP_1 := 2;
+  const TWO_UP_2 := 2 * 2;
   const TWO_UP_3 := 2 * TWO_UP_2;
   const TWO_UP_4 := TWO_UP_2 * TWO_UP_2;
-  const TWO_UP_5 := 2 * TWO_UP_2 * TWO_UP_2;
+  const TWO_UP_5 := 2 * TWO_UP_4;
   const TWO_UP_6 := 2 * TWO_UP_5;
   const TWO_UP_7 := 2 * TWO_UP_6;
   const TWO_UP_8 := 2 * TWO_UP_7;

--- a/src/dafny/ssz/Constants.dfy
+++ b/src/dafny/ssz/Constants.dfy
@@ -9,8 +9,6 @@ include "../utils/Eth2Types.dfy"
 module Constants {  
   import opened NativeTypes
 
-  import opened Eth2Types
-
   //  Powers of 2
   const TWO_UP_0 := 1;
   const TWO_UP_2 := 2 * TWO_UP_0;
@@ -125,14 +123,5 @@ module Constants {
 
   /** A 0 byte, all bits set to false. */
   const FALSE_BYTE := [false, false, false, false, false, false, false, false]
-  
-  /** An empty chunk, all 32 bytes set to zero */
-  const EMPTY_CHUNK:seq<byte> := [0, 0, 0, 0,
-                                  0, 0, 0, 0,
-                                  0, 0, 0, 0,
-                                  0, 0, 0, 0,
-                                  0, 0, 0, 0,
-                                  0, 0, 0, 0,
-                                  0, 0, 0, 0,
-                                  0, 0, 0, 0]
+
 } 

--- a/src/dafny/ssz/Eth2TypeDependentConstants.dfy
+++ b/src/dafny/ssz/Eth2TypeDependentConstants.dfy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may 
+ * not use this file except in compliance with the License. You may obtain 
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software dis-
+ * tributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
+ * License for the specific language governing permissions and limitations 
+ * under the License.
+ */
+
+include "../utils/Eth2Types.dfy"
+include "../utils/Helpers.dfy"
+
+module Eth2TypeDependentConstants {
+    import opened Eth2Types
+    import opened Helpers
+
+  /** An empty chunk, all 32 bytes set to zero */
+  const EMPTY_CHUNK:seq<byte> := [0, 0, 0, 0,
+                                  0, 0, 0, 0,
+                                  0, 0, 0, 0,
+                                  0, 0, 0, 0,
+                                  0, 0, 0, 0,
+                                  0, 0, 0, 0,
+                                  0, 0, 0, 0,
+                                  0, 0, 0, 0]
+
+    /** The default zeroed Bytes32.  */
+  const SEQ_EMPTY_32_BYTES := timeSeq<byte>(0,32)   
+
+  /**
+    *  The default (empty) Bytes32
+    */
+  const EMPTY_BYTES32 : Bytes32 := Bytes(SEQ_EMPTY_32_BYTES)
+}

--- a/src/dafny/utils/Eth2Types.dfy
+++ b/src/dafny/utils/Eth2Types.dfy
@@ -221,8 +221,6 @@ module Eth2Types {
     type Bytes96 = s:Serialisable | s.Bytes? && |s.bs| == 96
                                     witness Bytes(timeSeq(0 as byte, 96))
 
-    type Vector4 = s:Serialisable | s.Vector? && |s.v| == 4
-
     // EMPTY_BYTES32
 
     // const EMPTY_BYTES32 := Bytes32(SEQ_EMPTY_32_BYTES)

--- a/test/dafny/merkle/third_party_implementations/TestBeaconStateMerkleise.dfy
+++ b/test/dafny/merkle/third_party_implementations/TestBeaconStateMerkleise.dfy
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may 
+ * not use this file except in compliance with the License. You may obtain 
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software dis-
+ * tributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
+ * License for the specific language governing permissions and limitations 
+ * under the License.
+ */
+ 
+include "../../../../src/dafny/utils/NativeTypes.dfy"
+include "../../../../src/dafny/utils/Eth2Types.dfy"
+include "../../../../src/dafny/utils/Helpers.dfy"
+include "../../../../src/dafny/ssz/BytesAndBits.dfy"
+include "../../../../src/dafny/ssz/BitListSeDes.dfy"
+include "../../../../src/dafny/utils/DafTests.dfy"
+include "../../test_utils/StringConversions.dfy"
+include "../../../../src/dafny/merkle/Merkleise.dfy"
+include "../../../../src/dafny/beacon/helpers/Crypto.dfy"
+include "../../../lowlevel_modules/CommandLine.dfy"
+include "ThirdPartyMerkleisation.dfy"
+include "../../../lowlevel_modules/Rand.dfy"
+
+// This constant is required due to a bug in PySSZ which causes an exception to be 
+// thrown when building a uint64 type with a value >= MAX_VALUE_FOR_UINT64
+const MAX_VALUE_FOR_UINT64: nat := 0x100000000;
+
+/**
+ * Helper function.
+ *
+ * @returns A randomly generated `wellTyped` `RawSerialisable` value of `Tipe`
+ * `Uint64`
+ */
+function method {:fuel Rand.Rand,0,0} getRandomUint64(): Eth2Types.RawSerialisable
+ensures Eth2Types.wellTypedContainerField(getRandomUint64(),Eth2Types.Uint64_);
+{
+    var val := (Rand.Rand() as nat % MAX_VALUE_FOR_UINT64);
+    assert val < 0x10000000000000000;
+    Eth2Types.Uint64(val)
+}
+
+/**
+ * Helper lemma.
+ *
+ * A RawSerialisable value constructed with the Bytes constructor using a non
+ * empty sequence as parameter is `wellTyped`
+ */
+lemma lemmaWellTypedBytes(r:Eth2Types.RawSerialisable)
+requires r.Bytes?
+requires |r.bs| > 0
+ensures Eth2Types.wellTyped(r)
+{ }
+
+/** 
+ * Helper function.
+ * 
+ * @returns A randomly generated `Bytes32` value.
+ */
+function method {:fuel Rand.Rand,0,0} getRandomBytes32(): Eth2Types.Bytes32 
+{
+    var bs := Helpers.initSeq<Eth2Types.byte>((x:nat) => (Rand.Rand()% 0x100) as Eth2Types.byte,32);
+    assert |bs| == 32;
+    var r := Eth2Types.Bytes(bs);
+    lemmaWellTypedBytes(r);
+    r
+}
+
+/**
+ * Helper function.
+ *
+ * @returns A randomly generated `wellTyped` `RawSerialisable` value of `Tipe`
+ * `Vector_(Bytes_(32),SLOTS_PER_HISTORICAL_ROOT)`
+ */
+function method {:fuel getRandomBytes32,0,0} getRandomRootVector(): Eth2Types.RawSerialisable
+ensures Eth2Types.wellTypedContainerField(getRandomRootVector(), Eth2Types.Vector_(Eth2Types.Bytes_(32),Constants.SLOTS_PER_HISTORICAL_ROOT as nat));
+{
+    Eth2Types.Vector(getRandomRootSeq(Constants.SLOTS_PER_HISTORICAL_ROOT as nat))
+}
+
+/**
+ * Helper function for `getRandomRootVector`
+ * 
+ * @param n Number of elements
+ * @returns A randomly generated sequence of `n` `Bytes32` values
+ */
+function method {:fuel getRandomBytes32,0,0} getRandomRootSeq(n:nat): seq<Eth2Types.Bytes32>
+ensures |getRandomRootSeq(n)| == n
+ensures forall i | 0 <= i < |getRandomRootSeq(n)| :: Eth2Types.wellTyped(getRandomRootSeq(n)[i])
+{
+    if n == 0 then
+        []
+    else
+        [getRandomBytes32()] + getRandomRootSeq(n-1)
+}
+
+/**
+ * Helper function for the `verifyBeaconState` function
+ *
+ * @param n A natural number < 0x10000000000000000
+ * @returns `n` wrapped into a RawSerialisable constructed with the `Uint64`
+ *          constructor
+ */
+function method castToUint64(n:nat): Eth2Types.RawSerialisable
+requires n < 0x10000000000000000
+ensures castToUint64(n).Uint64?
+ensures Eth2Types.wellTypedContainerField(castToUint64(n),Eth2Types.Uint64_);
+{
+    var r:= Eth2Types.Uint64(n);
+    assert Eth2Types.wellTyped(r);
+    r
+}
+
+/**
+ * Helper lemma for the function `getRandomBeaconBlockHeader`
+ *
+ * A RawSerialisable value constructed using a `wellTyped` Uint64 value and two
+ * `Bytes32` values complies to the constraints of the `BeaconBlockHeader` type
+ */
+lemma lemmaWellTypedBeaconBlockHeader(slot:Eth2Types.RawSerialisable, parent_root:Eth2Types.Bytes32, state_root:Eth2Types.Bytes32)
+requires    Eth2Types.wellTypedContainerField(slot,Eth2Types.Uint64_)
+requires    Eth2Types.wellTypedContainerField(parent_root,Eth2Types.Bytes_(32))
+requires    Eth2Types.wellTypedContainerField(state_root,Eth2Types.Bytes_(32))
+ensures var bbh:= Eth2Types.BeaconBlockHeader(slot,parent_root,state_root);
+            && Eth2Types.wellTyped(bbh)
+            && Eth2Types.wellTypedContainerField(bbh,Eth2Types.BeaconBlockHeader_);
+{ }
+
+/**
+ * Helper function.
+ * 
+ * @returns A randomly generated `BeaconBlockHeader` value
+ */
+function method getRandomBeaconBlockHeader(): Eth2Types.BeaconBlockHeader
+ensures getRandomBeaconBlockHeader().BeaconBlockHeader?
+ensures Eth2Types.wellTyped(getRandomBeaconBlockHeader())
+ensures Eth2Types.typeOf(getRandomBeaconBlockHeader()) == Eth2Types.BeaconBlockHeader_
+{
+    var slot := getRandomUint64();
+    
+    var bs1: Eth2Types.Bytes32 := getRandomBytes32();
+
+    var bs2: Eth2Types.Bytes32 := getRandomBytes32();
+
+    lemmaWellTypedBeaconBlockHeader(slot,bs1,bs2);
+
+    Eth2Types.BeaconBlockHeader(
+        slot,
+        bs1,
+        bs2
+    )
+}
+
+/**
+ * Helper function.
+ * 
+ * @returns A randomly generated `BeaconState` value
+ */
+function method {:fuel getRandomBytes32,0,0} {:fuel Rand.Rand,0,0} getRandomBeaconState(): Eth2Types.BeaconState
+{
+    var slot := getRandomUint64();
+
+    var bbh  :=  getRandomBeaconBlockHeader();
+
+    var block_roots := getRandomRootVector();
+  
+    var state_roots := getRandomRootVector();
+
+    Eth2Types.BeaconState(
+        slot,
+        bbh,
+        block_roots,
+        state_roots
+    )
+}
+
+/**
+ * @param s A `BeaconState` value
+ *
+ * @returns True iff the hash tree root calculated by the third party
+ * markleisation function matches the value returned by the Dafny
+ * correct-by-construction merkleisation function
+ */
+predicate method verifyBeaconState(bs: Eth2Types.BeaconState, failPercentage: nat)
+requires bs.BeaconState?
+requires Eth2Types.wellTypedContainer(bs)
+requires 0 <= failPercentage <= 100
+{
+    var dfyHashRoot := SSZ_Merkleise.getHashTreeRoot(bs);
+
+    var ThirdPartyBeaconState: Eth2Types.BeaconState :=    
+                                if bs.slot.n >= MAX_VALUE_FOR_UINT64 * (100 - failPercentage) /100 then
+                                    var newS := castToUint64((bs.slot.n+1) % 0x10000000000000000);                                    
+                                    var newBs:=
+                                    Eth2Types.BeaconState(
+                                        newS,
+                                        bs.latest_block_header,
+                                        bs.block_roots,
+                                        bs.state_roots
+                                    );
+                                    assert Eth2Types.wellTypedContainer(newBs);
+                                    newBs
+                                    
+                                else
+                                    bs
+                                ;
+
+    var ThirdParthyHash := ThirdPartyMerkleisation.BeaconStateRoot(ThirdPartyBeaconState);
+
+    dfyHashRoot == ThirdParthyHash
+}
+
+/**
+ * Generate test items
+ * 
+ * @param numTests Number of test items to create
+ * @param perfFailure Percentage of tests that should fail
+ * 
+ * @returns A sequence of randomly generated test items
+ */
+function method CompileTest(numTests:nat, percFailure:nat) :seq<DafTest.TestItem>
+requires 0 <= percFailure <= 100
+ensures |CompileTest(numTests,percFailure)| == numTests
+{
+    CompileRecTest(numTests,percFailure,0)
+}
+
+/**
+ * Helper function for generating test items.
+ * 
+ * @param numTests Number of test items to create
+ * @param perfFailure Percentage of tests that should fail
+ * @param count Num of tests generated so far
+ * 
+ * @returns A sequence of randomly generated test items
+ */
+function method CompileRecTest(numTests:nat, percFailure:nat, count:nat) :seq<DafTest.TestItem>
+requires 0 <= percFailure <= 100
+ensures |CompileRecTest(numTests,percFailure,count)| == numTests
+{
+    if numTests == 0 then
+        []
+    else
+        [createTestItem(getRandomBeaconState(),percFailure,count)] +
+        CompileRecTest(numTests-1,percFailure,count+1)
+}
+
+/**
+ * Create a test item.
+ * 
+ * @param bs BeaconState value to test
+ * @param perfFailure Percentage of tests that should fail
+ * @param count Num of tests generated so far
+ * 
+ * @returns A test item
+ */
+function method createTestItem(bs: Eth2Types.BeaconState, percFailure: nat, count:nat): DafTest.TestItem
+requires bs.BeaconState?
+requires Eth2Types.wellTypedContainer(bs)
+requires 0 <= percFailure <= 100
+{
+    DafTest.TestItem(
+                "Test #"
+                + StringConversions.itos(count+1)
+                + "\n"
+            ,
+                () => verifyBeaconState(bs,percFailure)
+    )
+}
+
+/**
+ * Validate command line arguments
+ * 
+ * @param args Command line arguments
+ * 
+ * @returns true iff the command line arguments are well formed
+ */
+predicate method correctInputParameters(args: seq<string>)
+{
+    && |args| == 3
+    && StringConversions.isNumber(args[1])
+    && StringConversions.isNumber(args[2])
+    && 0 <= StringConversions.atoi(args[2]) <= 100
+}
+
+/**
+ * Execution Entry Point
+ */
+method Main()
+{
+    var args := GetCommandLineParamters();
+
+    if(correctInputParameters(args))
+    {
+        var numTests := StringConversions.atoi(args[1]);
+        var percFailure := StringConversions.atoi(args[2]);
+
+        var fixedTest := [];
+
+        var tests :=    fixedTest +
+                        CompileTest(numTests,percFailure);
+
+
+        var merkleTestSuite := DafTest.TestSuite("Beacon State Merkleisation",tests[..numTests]);
+
+        DafTest.executeTests(merkleTestSuite);
+    }
+    else
+    {
+        print "First argument must be a natural number indicating the number of tests.\n";
+        print "The second argument must be a natural number between 0 and 100 (included) which specifies the average percentage of tests that should fail.\n";
+    }
+}
+
+/**
+ * This is just to ensure the tye "mycrypto" module is reference otherwise the
+ * Go compiler throws an error
+ */
+method dummy_method()
+{
+    var dummy := Crypto.hash([]);
+}

--- a/test/dafny/merkle/third_party_implementations/ThirdPartyMerkleisation.dfy
+++ b/test/dafny/merkle/third_party_implementations/ThirdPartyMerkleisation.dfy
@@ -27,4 +27,6 @@ module {:extern "thirdpartymerkleisation"} ThirdPartyMerkleisation {
 
     function method {:extern} ListBytes32Root(l: seq<seq<byte>>, limit:nat): hash32
     requires forall i |  0 <= i < |l| :: |l[i]| == 32
+
+    function method {:extern} BeaconStateRoot(s:BeaconState): hash32
 }

--- a/test/dafny/merkle/third_party_implementations/compilePySszBeaconState4Merkleisation.sh
+++ b/test/dafny/merkle/third_party_implementations/compilePySszBeaconState4Merkleisation.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Copyright 2020 ConsenSys AG.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may 
+# not use this file except in compliance with the License. You may obtain 
+# a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software dis-
+# tributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
+# License for the specific language governing permissions and limitations 
+# under the License.
+
+dafny /compile:1 /compileTarget:cs /spillTargetCode:1 TestBeaconStateMerkleise.dfy ../../../lowlevel_modules/CommandLine.cs  ../../../lowlevel_modules/Rand.cs ../../../../src/dafny/beacon/helpers/Crypto.cs PySszMerkleisation.cs

--- a/test/lowlevel_modules/Rand.cs
+++ b/test/lowlevel_modules/Rand.cs
@@ -21,9 +21,9 @@ namespace myrand
     
     public partial class __default {
         private static Random rnd = new Random();
-        public static BigInteger Rand()
+        public static UInt64 Rand()
         {
-            return (BigInteger) rnd.Next();
+            return (UInt64) (rnd.NextDouble() * UInt64.MaxValue);
         }
     }
 }

--- a/test/lowlevel_modules/Rand.dfy
+++ b/test/lowlevel_modules/Rand.dfy
@@ -12,12 +12,10 @@
  * under the License.
  */
  
-include "../../src/dafny/utils/Helpers.dfy"
-include "../../src/dafny/utils/Eth2Types.dfy"
+include "../../src/dafny/utils/NativeTypes.dfy"
 
 module {:extern "myrand"} Rand {
-    import opened Eth2Types
     import opened NativeTypes
 
-    function method {:extern} Rand():nat
+    function method {:extern} Rand():uint64
 }


### PR DESCRIPTION
This PR presents an option for integrating the containers used in the Beacon Chain section of the specs with the SSZ and Merkleise sections.

**Note:** Due to Dafny bug [#703](https://github.com/dafny-lang/dafny/issues/703), Dafny can correctly verify the `BeaconConstants.dfy` file only if it is not supplied to the `dafny` executable together with either of the `ForkChoice.dfy` and `StateTransition.dfy` files.